### PR TITLE
Added movie list retrieval from Rotten API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ROTTEN_KEY=fhyuqea7nwpjmd6bf7a3uaem

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,13 @@
 source 'https://rubygems.org'
 
+ruby '2.2.0'
+
 gem 'activerecord'
-gem 'pry'
 gem 'sqlite3'
 gem 'minitest'
 gem 'sinatra', git: 'https://github.com/sinatra/sinatra.git'
 gem 'httparty'
 gem 'rake'
+gem 'dotenv'
+
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,64 @@
+GIT
+  remote: https://github.com/sinatra/sinatra.git
+  revision: be9c18ac44214069f4709ced6da65abba9501d24
+  specs:
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.2.0)
+      activesupport (= 4.2.0)
+      builder (~> 3.1)
+    activerecord (4.2.0)
+      activemodel (= 4.2.0)
+      activesupport (= 4.2.0)
+      arel (~> 6.0)
+    activesupport (4.2.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    arel (6.0.0)
+    builder (3.2.2)
+    coderay (1.1.0)
+    dotenv (1.0.2)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    i18n (0.7.0)
+    json (1.8.2)
+    method_source (0.8.2)
+    minitest (5.5.1)
+    multi_xml (0.5.5)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rack (1.6.0)
+    rack-protection (1.5.3)
+      rack
+    rake (10.4.2)
+    slop (3.6.0)
+    sqlite3 (1.3.10)
+    thread_safe (0.3.4)
+    tilt (2.0.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  dotenv
+  httparty
+  minitest
+  pry
+  rake
+  sinatra!
+  sqlite3

--- a/lib/movie.rb
+++ b/lib/movie.rb
@@ -1,4 +1,41 @@
+require 'httparty'
+
+require 'dotenv'
+Dotenv.load
+
+require 'pry'
+
 class Movie < ActiveRecord::Base
   has_many :users, through: :user_movie
   has_many :comments
+
+  include HTTParty
+  format :json
+  
+  ROTTEN_KEY = ENV.fetch("ROTTEN_KEY")
+
+  # will only create movie if it does not already exist in system.
+  # Retrieves upcoming movies to a max of 16 by default
+  def self.generate_upcoming_movie_list!
+    m = JSON.parse(HTTParty.get("http://api.rottentomatoes.com/api/public/v1.0/lists/movies/upcoming.json?apikey=#{ROTTEN_KEY}"))
+
+    count = 0
+    total_movies = m["total"]
+
+    total_movies.times do
+      movie_exists = Movie.find_by(rotten_id: m["movies"][count]["id"]) || nil
+      if movie_exists
+        Movie.create!(
+          title: m["movies"][count]["title"],
+          thumbnail: m["movies"][count]["posters"]["thumbnail"],
+          release_date: m["movies"][count]["release_dates"]["theater"],
+          synopsis: m["movies"][count]["synopsis"],
+          rotten_id: m["movies"][count]["id"]
+        )
+      end
+      count += 1  
+    end
+
+  end
+
 end

--- a/rottenmovies.rb
+++ b/rottenmovies.rb
@@ -8,7 +8,7 @@ require './lib/all'
 class Rottenmovies < Sinatra::Base
   
   get '/' do
-
+    @movies = Movie.all # restrict to current month at some point?
     erb :upcoming
   end
 
@@ -28,3 +28,5 @@ class Rottenmovies < Sinatra::Base
   end
 
 end
+
+Rottenmovies.run!

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" rel="stylesheet">
+  <title>Rotten Movies</title>
+</head>
+
+<%= yield %>
+
+</body>
+</html>

--- a/views/upcoming.erb
+++ b/views/upcoming.erb
@@ -1,0 +1,24 @@
+<div class="container">
+  
+  <table class="table table-bordered table-hover">
+    
+    <tr>
+      <td>
+        <img src="<%= @movies.first.thumbnail %>" />
+      </td>
+      <td>
+        <%= @movies.first.title %>
+      </td>
+      <td>
+        <%= @movies.first.rotten_id %>
+      </td>
+      <td>
+        <%= @movies.first.release_date %>
+      </td>
+      <td>
+        <%= @movies.first.synopsis %>
+      </td>
+    </tr>
+  </table>
+
+</div>


### PR DESCRIPTION
- Added function to retrieve upcoming movie list from Rotten Tomatoes API.  Max by default is 16 and only retrieves for the current month you are in.  Can change settings if needed.
- Added sample '/' view to see the movie data.
